### PR TITLE
Automatically build with GitHub actions

### DIFF
--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Install xvfb and subversion
-        run: sudo apt-get update && sudo apt-get install -y xvfb subversion
+        run: apt-get update && apt-get install -y xvfb subversion
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: nz.mega.MEGAsync.aarch64.flatpak

--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
+      - name: Install xvfb and subversion
+        run: sudo apt-get update && sudo apt-get install -y xvfb subversion
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: nz.mega.MEGAsync.aarch64.flatpak

--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
-          bundle: nz.mega.MEGAsync.aarch64.flatpak
+          bundle: nz.mega.MEGAsync-${{ github.ref_name }}.aarch64.flatpak
           manifest-path: nz.mega.MEGAsync.yml
           cache-key: flatpak-builder-${{ github.sha }}-aarch64
           arch: aarch64
@@ -25,10 +25,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: flatpak-bundle-aarch64
-          path: nz.mega.MEGAsync.aarch64.flatpak
+          path: nz.mega.MEGAsync-${{ github.ref_name }}.aarch64.flatpak
 
       - name: Upload to GitHub Release
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
         with:
-          files: nz.mega.MEGAsync.aarch64.flatpak
+          files: nz.mega.MEGAsync-${{ github.ref_name }}.aarch64.flatpak

--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -1,0 +1,34 @@
+name: Build Flatpak (ARM only)
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  flatpak:
+    name: "Flatpak ARM"
+    container:
+      image: ghcr.io/flathub-infra/flatpak-github-actions:kde-5.15-24.08
+      options: --privileged
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
+        with:
+          bundle: nz.mega.MEGAsync.aarch64.flatpak
+          manifest-path: nz.mega.MEGAsync.yml
+          cache-key: flatpak-builder-${{ github.sha }}-aarch64
+          arch: aarch64
+
+      - name: Upload Flatpak as Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: flatpak-bundle-aarch64
+          path: nz.mega.MEGAsync.aarch64.flatpak
+
+      - name: Upload to GitHub Release
+        if: github.event_name == 'release'
+        uses: softprops/action-gh-release@v2
+        with:
+          files: nz.mega.MEGAsync.aarch64.flatpak

--- a/.github/workflows/flatpak-build.yml
+++ b/.github/workflows/flatpak-build.yml
@@ -14,8 +14,6 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-      - name: Install xvfb and subversion
-        run: apt-get update && apt-get install -y xvfb subversion
       - uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:
           bundle: nz.mega.MEGAsync.aarch64.flatpak

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.flatpak-builder/
+build-dir

--- a/README.md
+++ b/README.md
@@ -5,7 +5,15 @@ I am not affiliated with Mega.
 
 ## Install instructions
 
-Install `flatpak`, `flatpak-builder`, and use `flatpak` to install `org.kde.Sdk`. 
+First, [install flatpak and set up flathub](https://flathub.org/setup) (required to download dependencies).
+Then, download the prebuilt .flatpak from [GitHub releases](https://github.com/zarandya/megasync-nocrashhandler/releases), and install it with
+```
+flatpak install --user /path/to/nz.mega.MEGAsync-version_number.aarch64.flatpak
+```
+
+----
+
+Or, if you want to manually build it, install `flatpak`, `flatpak-builder`, and use `flatpak` to install `org.kde.Sdk`. 
 
 `flatpak-builder --user --install --force-clean build nz.mega.MEGAsync.yml`
 

--- a/nz.mega.MEGAsync.yml
+++ b/nz.mega.MEGAsync.yml
@@ -37,8 +37,9 @@ modules:
       env:
         DESKTOP_DESTDIR: /app
       cxxflags: -Wno-dev
-      build-commands:
-        - dnf install -y xorg-x11-server-Xvfb
+      # Add build-deps (without it GitHub actions will fail)
+      build-deps:
+        - xorg-x11-server-Xvfb
     config_opts:
       -  -DCMAKE_BUILD_TYPE:STRING='None'
       -  -DCMAKE_MODULE_PATH:PATH="src/MEGASync/mega/contrib/cmake/modules/packages"

--- a/nz.mega.MEGAsync.yml
+++ b/nz.mega.MEGAsync.yml
@@ -37,6 +37,8 @@ modules:
       env:
         DESKTOP_DESTDIR: /app
       cxxflags: -Wno-dev
+      build-commands:
+        - dnf install -y xorg-x11-server-Xvfb
     config_opts:
       -  -DCMAKE_BUILD_TYPE:STRING='None'
       -  -DCMAKE_MODULE_PATH:PATH="src/MEGASync/mega/contrib/cmake/modules/packages"


### PR DESCRIPTION
This will close #2 

How to use:

After merging, **create a [release](https://github.com/zarandya/megasync-nocrashhandler/releases) with a tag** that has the same version number as the [official mega release](https://github.com/meganz/MEGAsync/releases) you are targeting.

Then, GitHub actions will automatically build a flatpak and upload it to the release (for example, see this https://github.com/archisman-panigrahi/megasync-nocrashhandler/releases).

It takes about 29 minutes for GitHub actions to build it.

**No other user input is necessary - just edit manifest to point to the correct source to update the flatpak, and make a release with a tag.** GitHub will build and attach the flatpak to your release within half an hour. You can see its progress [here](https://github.com/zarandya/megasync-nocrashhandler/actions).

I tested the flatpak in my underpowered ARM Chromebook, and it works there! It simply does not have enough memory and diskspace to build the flatpak (and even it had, it may have taken days to complete the build) -- but installing the prebuilt flatpak is easy.


Now this flatpak can be used in Raspberry Pis, ARM Chromebooks, and every other ARM machine (including Apple silicon) running GNU/Linux.